### PR TITLE
Use casecmp for comparison to avoid case sensitive check - task - #1b33n4x

### DIFF
--- a/lib/query_helper/sql_sort.rb
+++ b/lib/query_helper/sql_sort.rb
@@ -31,7 +31,7 @@ class QueryHelper
         direction = sort.split(":")[1]
         modifier = sort.split(":")[2]
         begin
-          sql_expression = @column_maps.find{ |m| m.alias_name == sort_alias }.sql_expression
+          sql_expression = @column_maps.find{ |m| m.alias_name.casecmp?(sort_alias) }.sql_expression
         rescue NoMethodError => e
           raise InvalidQueryError.new("Sorting not allowed on column '#{sort_alias}'")
         end


### PR DESCRIPTION
### Description
Resolved below error
QueryHelper::InvalidQueryError (Sorting not allowed on column 'appearance_scaled')

Problem Statement
If we are passing sort=appearance_scaled as a sort params so current algorithm check "APPEARANCE_SCALED" == "appearance_scaled".
So in that case it didn't find "appearance_scaled" in column_maps and raise the error.

So I used "casecmp?" instead of "==" to avoid this problem.

#### Clickup Story
https://app.clickup.com/t/1b33n4x

#### Deployment Details
Standard Process

#### QA Guide
Need to confirm no 500 occurs while hitting the below API.
https://predict-staging.netlify.app/staging-adczar/api/v2/destiny/products/727110/shelf?currency_code=USD&order=desc&sort=appearance_scaled

Reminders
- [ ] All scenarios are tested
- [ ] Test cases added if required
- [ ] Schema and migrations are updated
- [ ] A11y guidelines are followed [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/)
