### PR TITLE
Support enum based sorting

### DIFF
--- a/lib/query_helper.rb
+++ b/lib/query_helper.rb
@@ -67,6 +67,7 @@ class QueryHelper
     sql_filter: nil,
     sql_sort: nil,
     sort_tiebreak: nil,
+    column_sort_order: nil,
     page: nil,
     per_page: nil,
     search_string: nil,
@@ -85,6 +86,7 @@ class QueryHelper
     @sql_filter = sql_filter if sql_filter
     @sql_sort = sql_sort if sql_sort
     @sql_sort.sort_tiebreak = sort_tiebreak if sort_tiebreak
+    @sql_sort.column_sort_order = column_sort_order if column_sort_order
     @search_string = search_string if search_string
     @page = determine_page(page: page, per_page: per_page) if page
     @per_page = determine_per_page(page: page, per_page: per_page) if per_page

--- a/lib/query_helper/query_helper_concern.rb
+++ b/lib/query_helper/query_helper_concern.rb
@@ -31,7 +31,7 @@ class QueryHelper
       end
 
       def create_query_helper_sort
-        QueryHelper::SqlSort.new(sort_string: params[:sort], sort_tiebreak: params[:sort_tiebreak])
+        QueryHelper::SqlSort.new(sort_string: params[:sort], sort_tiebreak: params[:sort_tiebreak], column_sort_order: params[:column_sort_order])
       end
 
       def create_query_helper_associations

--- a/lib/query_helper/version.rb
+++ b/lib/query_helper/version.rb
@@ -1,3 +1,3 @@
 class QueryHelper
-  VERSION = "0.2.22"
+  VERSION = "0.2.23"
 end


### PR DESCRIPTION
Adding these changes for the below scenario:
customer_type is the enum in iserve
group_type is the enum in iserve
While implementing Standard Table Component on Settings > Customer and Settings > User & Group > Groups page, need sorting on Customer Type and Group Type Column.

Added new attribute  `column_sort_order` as array in `SqlSort` class.
If the `column_sort_order` has values then added code to use enum type sorting otherwise it will use normal SQL expression. 

Query will look like this:
` SELECT groups.*, COUNT(DISTINCT customers.id) AS customers_count, COUNT(DISTINCT users.id) AS users_count , count(*) over () as _query_full_count FROM "groups" LEFT JOIN users ON users.group_id = groups.id LEFT JOIN user_customers ON user_customers.user_id = users.id LEFT JOIN customers ON customers.id = user_customers.customer_id LEFT JOIN group_user_types ON group_user_types.group_id = groups.id WHERE "groups"."status" != 'deleted' GROUP BY groups.id order by (CASE WHEN group_type = 0 THEN 0 WHEN group_type = 3 THEN 1 WHEN group_type = 2 THEN 2 WHEN group_type = 1 THEN 3 END ) desc nulls last limit 20 offset 0`
 
From Rails Side, we just need to add this params in controller 
params[:column_sort_order] = [0,3,2,1] if params[:sort].include? "group_type"

No API changes required from frontend side. 