### PR TITLE
order changes for the qualify clause

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    query_helper (0.2.28)
+    query_helper (0.2.29)
       activerecord (> 5)
       activesupport (> 5)
       sqlite3

--- a/lib/query_helper/sql_manipulator.rb
+++ b/lib/query_helper/sql_manipulator.rb
@@ -83,7 +83,7 @@ class QueryHelper
 
       begin_string = @parser.qualify_included? ? "and" : "qualify"
       filter_string = @qualify_clauses.join(" and ")
-      @sql.insert(@parser.insert_where_index, " #{begin_string} #{filter_string} ")
+      @sql.insert(@parser.insert_qualify_index, " #{begin_string} #{filter_string} ")
     end
 
     def qualify_clause_applicable?

--- a/lib/query_helper/sql_parser.rb
+++ b/lib/query_helper/sql_parser.rb
@@ -117,6 +117,10 @@ class QueryHelper
       group_by_index() || order_by_index() || limit_index() || @sql.length
     end
 
+    def insert_qualify_index
+      order_by_index() || limit_index() || @sql.length
+    end
+
     def insert_having_index
       # raise InvalidQueryError.new("Cannot calculate insert_having_index because the query has no group by clause") unless group_by_included?
       order_by_index() || limit_index() || @sql.length

--- a/lib/query_helper/version.rb
+++ b/lib/query_helper/version.rb
@@ -1,3 +1,3 @@
 class QueryHelper
-  VERSION = "0.2.28"
+  VERSION = "0.2.29"
 end

--- a/spec/query_helper/sql_manipulator_spec.rb
+++ b/spec/query_helper/sql_manipulator_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe QueryHelper::SqlManipulator do
   let(:order_by_clauses) { [] }
   let(:include_limit_clause) { false }
   let(:additional_select_clauses) { [] }
+  let(:parser) { QueryHelper::SqlParser.new(sql) }
 
   describe "#build" do
     context "add where_clauses" do
@@ -80,6 +81,10 @@ RSpec.describe QueryHelper::SqlManipulator do
 
       it "adds qualify clause to query" do
         expect(manipulator).to eq("SELECT * FROM TESTING qualify percentage > 1.0")
+      end
+
+      it "verifies qualify clause to query at the correct position, as per the query life cycle" do
+        expect(parser.insert_qualify_index).to eq(manipulator.index(' qualify'))
       end
 
       context "when paginated results" do


### PR DESCRIPTION
### Description
Reordered the qualify clause in the SQL query, as it has a different life cycle as compared to other clauses and it was failing in case a query has a group by clause along with the qualify clause.