### PR TITLE
Qualify statement bug fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    query_helper (0.2.30)
+    query_helper (0.3.1)
       activerecord (> 5)
       activesupport (> 5)
       sqlite3
@@ -43,13 +43,13 @@ GEM
       i18n (>= 0.7)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    loofah (2.12.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.8.0)
     minitest (5.14.4)
-    nokogiri (1.13.3)
+    nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.0)
@@ -59,7 +59,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     railties (6.1.4.1)
       actionpack (= 6.1.4.1)
@@ -89,7 +89,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    sqlite3 (1.4.2)
+    sqlite3 (1.4.4)
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)

--- a/lib/query_helper/sql_manipulator.rb
+++ b/lib/query_helper/sql_manipulator.rb
@@ -26,8 +26,8 @@ class QueryHelper
     end
 
     def build
-      insert_having_clauses()
       insert_qualify_clauses()
+      insert_having_clauses()
       insert_where_clauses()
       insert_select_clauses()
       insert_order_by_and_limit_clause()

--- a/lib/query_helper/sql_manipulator.rb
+++ b/lib/query_helper/sql_manipulator.rb
@@ -49,7 +49,7 @@ class QueryHelper
 
     def qualify_clauses(index)
       if index == 0
-        "qualified_results AS ( "
+        "WITH qualified_results AS ( "
       else
         ", qualified_results AS ( "
       end

--- a/lib/query_helper/version.rb
+++ b/lib/query_helper/version.rb
@@ -1,3 +1,3 @@
 class QueryHelper
-  VERSION = "0.2.30"
+  VERSION = "0.3.1"
 end

--- a/spec/query_helper/sql_manipulator_spec.rb
+++ b/spec/query_helper/sql_manipulator_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe QueryHelper::SqlManipulator do
           let(:sql) { "qualified_results AS ( SELECT report.* FROM report qualify percentage > 1.0 limit :limit offset :offset ) SELECT qualified_results.*, count(*) over () as _query_full_count FROM qualified_results" }
 
           it "adds qualify clause to query" do
-            expect(manipulator).to eq(sql)
+            expect(manipulator).to eq("WITH qualified_results AS ( SELECT report.* FROM report qualify percentage > 1.0 limit :limit offset :offset ) SELECT qualified_results.*, count(*) over () as _query_full_count FROM qualified_results")
           end
         end
 
@@ -110,7 +110,7 @@ RSpec.describe QueryHelper::SqlManipulator do
           let(:sql) { "SELECT * FROM TESTING" }
 
           it "adds qualify clause to query" do
-            expect(manipulator).to eq("qualified_results AS ( SELECT * FROM TESTING qualify percentage > 1.0 limit :limit offset :offset ) SELECT qualified_results.*, count(*) over () as _query_full_count FROM qualified_results")
+            expect(manipulator).to eq("WITH qualified_results AS ( SELECT * FROM TESTING qualify percentage > 1.0 limit :limit offset :offset ) SELECT qualified_results.*, count(*) over () as _query_full_count FROM qualified_results")
           end
         end
       end


### PR DESCRIPTION
## Description
This PR consists of two small bug fixes around generating qualify statements and the qualifed_results cte in the sql_manipulator.rb.

1. If the "select" index is 0, then the statement should be "WITH qualified_results as (".
2. Update the order in which the having and the qualify statements are injected into the query to ensure that the 'qualify' statement is after 'having'.