### PR TITLE
Add patch for the rails 7 preloader api

### DIFF
--- a/lib/query_helper/associations.rb
+++ b/lib/query_helper/associations.rb
@@ -8,12 +8,24 @@ class QueryHelper
     def self.load_associations(payload:, associations: [], as_json_options: {})
       as_json_options ||= {}
       as_json_options[:include] = as_json_options[:include] || json_associations(associations)
-      ActiveRecord::Associations::Preloader.new.preload(payload, associations)
+      begin
+        # Preloader have been changed in Rails 7, which is giving error on upgrade.
+        # This should be updated to latest API once all repos have been upgraded to Rails 7
+        ActiveRecord::Associations::Preloader.new.preload(payload, associations)
+      rescue
+        ActiveRecord::Associations::Preloader.new(records: payload, associations: associations).call
+      end
       payload.as_json(as_json_options)
     end
 
     def self.preload_associations(payload:, preload: [])
-      ActiveRecord::Associations::Preloader.new.preload(payload, preload)
+      begin
+        # Preloader have been changed in Rails 7, which is giving error on upgrade.
+        # This should be updated to latest API once all repos have been upgraded to Rails 7
+        ActiveRecord::Associations::Preloader.new.preload(payload, preload)
+      rescue
+        ActiveRecord::Associations::Preloader.new(records: payload, associations: preload).call
+      end
     end
 
     def self.json_associations(associations)


### PR DESCRIPTION
In rails 7 preloader API have been changed https://github.com/rails/rails/blob/main/activerecord/lib/active_record/associations/preloader.rb
Added a patch to support rails 7 API.