### PR TITLE
Fix case sensitivity in search fields and filter alias matching

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    query_helper (0.4.4)
+    query_helper (0.4.5)
       activerecord (> 5)
       activesupport (> 5)
       sqlite3

--- a/lib/query_helper.rb
+++ b/lib/query_helper.rb
@@ -282,7 +282,7 @@ class QueryHelper
       raise ArgumentError.new("search_fields not defined") unless @search_fields.length > 0
       placement = :where
       maps = column_maps.select do |cm|
-        if @search_fields.include? cm.alias_name
+        if @search_fields.map(&:downcase).include? cm.alias_name.downcase
           placement = :having if cm.aggregate
           true
         else

--- a/lib/query_helper.rb
+++ b/lib/query_helper.rb
@@ -282,7 +282,7 @@ class QueryHelper
       raise ArgumentError.new("search_fields not defined") unless @search_fields.length > 0
       placement = :where
       maps = column_maps.select do |cm|
-        if @search_fields.map(&:downcase).include? cm.alias_name.downcase
+        if @search_fields.any? { |sf| sf.casecmp?(cm.alias_name) }
           placement = :having if cm.aggregate
           true
         else

--- a/lib/query_helper/sql_filter.rb
+++ b/lib/query_helper/sql_filter.rb
@@ -17,7 +17,7 @@ class QueryHelper
 
       @filter_values.each do |comparate_alias, criteria|
         # Find the sql mapping if it exists
-        map = @column_maps.find { |m| m.alias_name == comparate_alias }
+        map = @column_maps.find { |m| m.alias_name.downcase == comparate_alias.downcase }
         raise InvalidQueryError.new("cannot filter by #{comparate_alias}") unless map
 
         # create the filter

--- a/lib/query_helper/sql_filter.rb
+++ b/lib/query_helper/sql_filter.rb
@@ -17,7 +17,7 @@ class QueryHelper
 
       @filter_values.each do |comparate_alias, criteria|
         # Find the sql mapping if it exists
-        map = @column_maps.find { |m| m.alias_name.downcase == comparate_alias.downcase }
+        map = @column_maps.find { |m| m.alias_name.casecmp?(comparate_alias) }
         raise InvalidQueryError.new("cannot filter by #{comparate_alias}") unless map
 
         # create the filter

--- a/lib/query_helper/version.rb
+++ b/lib/query_helper/version.rb
@@ -1,3 +1,3 @@
 class QueryHelper
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end


### PR DESCRIPTION
Improvements to case-insensitivity in filtering and searching:

* Made the search filter in `search_filter` compare alias names in a case-insensitive way by downcasing both the search fields and the column map alias names (`lib/query_helper.rb`).
* Updated the filter creation logic in `create_filters` to perform case-insensitive matching when finding column maps by alias name (`lib/query_helper/sql_filter.rb`).
* Bumped up the version from `0.4.4` to `0.4.5` in `version.rb`