### PR TITLE
Fix CI config by ensuring deployment unset before installing dependencies

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   brakeman:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_DEPLOYMENT: false
     steps:
       - uses: actions/checkout@v2
 
@@ -14,13 +16,7 @@ jobs:
           # Not needed with a .ruby-version file
           ruby-version: 2.7.2
           # runs 'bundle install' and caches installed gems automatically
-          # bundler-cache: true 
-          
-      - name: unset deployment
-        run: bundle config unset deployment
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
 
       - name: Brakeman install
         run: gem install brakeman -v 5.4.1

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -14,7 +14,13 @@ jobs:
           # Not needed with a .ruby-version file
           ruby-version: 2.7.2
           # runs 'bundle install' and caches installed gems automatically
-          bundler-cache: true
+          # bundler-cache: true 
+          
+      - name: unset deployment
+        run: bundle config unset deployment
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Brakeman install
         run: gem install brakeman -v 5.4.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_DEPLOYMENT: false
     steps:
       - uses: actions/checkout@v2
 
@@ -18,13 +20,7 @@ jobs:
           # Not needed with a .ruby-version file
           ruby-version: 2.7.2
           # runs 'bundle install' and caches installed gems automatically
-          # bundler-cache: true
-
-      - name: unset deployment
-        run: bundle config unset deployment
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
 
       - name: Run tests
         run: bundle exec rspec spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,13 @@ jobs:
           # Not needed with a .ruby-version file
           ruby-version: 2.7.2
           # runs 'bundle install' and caches installed gems automatically
-          bundler-cache: true
+          # bundler-cache: true
+
+      - name: unset deployment
+        run: bundle config unset deployment
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Run tests
         run: bundle exec rspec spec


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both Brakeman and CI jobs to improve dependency installation reliability. The main change is replacing the use of `bundler-cache: true` with explicit steps to unset the bundler deployment mode and manually install dependencies.

Dependency installation process updates:
* Removed `bundler-cache: true` and added steps to unset the bundler deployment configuration and run `bundle install` manually in both `.github/workflows/brakeman.yml` and `.github/workflows/ci.yml`. This helps avoid issues with cached gems and deployment-specific bundler settings. [[1]](diffhunk://#diff-44529fb6e227a6364059d067de38ae3671d17e33d02604c2ce01482aaa91e0bdL17-R23) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL21-R27)