### PR TITLE
Onboard query-helper to Backstage

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: query-helper
+  description: 'A Onboard an Existing Repo to Backstage created via Backstage'
+  annotations:
+    repo: patterninc/query_helper
+  labels:
+    CostCenter: PXM
+    Environment: stage
+    Name: query-helper
+    Owner: dev-pxm
+    Department: PXM
+    CreatedBy: Backstage
+spec:
+  type: service
+  system: pxm


### PR DESCRIPTION
Adds a `backstage.yaml` catalog descriptor so this repo appears in
the Backstage catalog.

Opened automatically by the *Onboard an Existing Repo to Backstage*
scaffolder template.
